### PR TITLE
Updates CQRS package dependencies

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -7,6 +7,8 @@
     <mapping directory="$PROJECT_DIR$/vendor/dhii/cqrs-resource-model-interface" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/dhii/data-container-interface" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/dhii/expression-interface" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/expression-renderer-abstract" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/expression-renderer-base" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/dhii/expression-renderer-interface" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/dhii/factory-base" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/dhii/file-finder-abstract" vcs="Git" />
@@ -25,7 +27,9 @@
     <mapping directory="$PROJECT_DIR$/vendor/rebelcode/expression-wp-query-builder" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/rebelcode/modular" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/rebelcode/module-iterator-abstract" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/rebelcode/rcmod-wp-cqrs" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/rebelcode/sql-cqrs-resource-models-abstract" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/rebelcode/sql-expression-renderer" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/rebelcode/wp-cqrs-resource-models" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/symfony/config" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/vendor/symfony/console" vcs="Git" />

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-mysqli": "^0.1",
         "rebelcode/modular": "^0.1-alpha1",
         "rebelcode/sql-cqrs-resource-models-abstract": "^0.2-alpha1",
-        "rebelcode/wp-cqrs-resource-models": "dev-develop",
+        "rebelcode/wp-cqrs-resource-models": "0.2-alpha1",
         "dhii/data-object-abstract": "^0.1-alpha1",
         "dhii/placeholder-template": "^0.1-alpha2"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^5.4 | ^7.0",
+        "ext-mysqli": "^0.1",
         "rebelcode/modular": "^0.1-alpha1",
         "rebelcode/sql-cqrs-resource-models-abstract": "^0.2-alpha1",
         "rebelcode/wp-cqrs-resource-models": "dev-develop",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^5.4 | ^7.0",
         "rebelcode/modular": "^0.1-alpha1",
         "rebelcode/sql-cqrs-resource-models-abstract": "^0.2-alpha1",
-        "rebelcode/wp-cqrs-resource-models": "^0.1-alpha1",
+        "rebelcode/wp-cqrs-resource-models": "dev-develop",
         "dhii/data-object-abstract": "^0.1-alpha1",
         "dhii/placeholder-template": "^0.1-alpha2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4070ed98ee645018d788245c862dc16b",
+    "content-hash": "4d09a2978c287884ae014d1fb5ec80c5",
     "packages": [
         {
             "name": "dhii/args-list-validation",
@@ -209,16 +209,16 @@
         },
         {
             "name": "dhii/container-helper-base",
-            "version": "v0.1-alpha7",
+            "version": "v0.1-alpha8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/container-helper-base.git",
-                "reference": "622671534124d95c1478a744e4d903b4d071f674"
+                "reference": "1b8206842e06b71abcff769aaddfc51bf8f317cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/container-helper-base/zipball/622671534124d95c1478a744e4d903b4d071f674",
-                "reference": "622671534124d95c1478a744e4d903b4d071f674",
+                "url": "https://api.github.com/repos/Dhii/container-helper-base/zipball/1b8206842e06b71abcff769aaddfc51bf8f317cd",
+                "reference": "1b8206842e06b71abcff769aaddfc51bf8f317cd",
                 "shasum": ""
             },
             "require": {
@@ -254,7 +254,7 @@
                 }
             ],
             "description": "Helper functionality for working with container.",
-            "time": "2018-04-10T15:03:55+00:00"
+            "time": "2018-07-30T09:59:15+00:00"
         },
         {
             "name": "dhii/cqrs-resource-model-interface",
@@ -1764,16 +1764,16 @@
         },
         {
             "name": "dhii/sql-interface",
-            "version": "dev-develop",
+            "version": "v0.1-alpha1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/sql-interface.git",
-                "reference": "465286d833deff37707ec2cc96884e60e31212d5"
+                "reference": "b600c3db8a41a739fe8f2006fad6f0412b245aad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/sql-interface/zipball/465286d833deff37707ec2cc96884e60e31212d5",
-                "reference": "465286d833deff37707ec2cc96884e60e31212d5",
+                "url": "https://api.github.com/repos/Dhii/sql-interface/zipball/b600c3db8a41a739fe8f2006fad6f0412b245aad",
+                "reference": "b600c3db8a41a739fe8f2006fad6f0412b245aad",
                 "shasum": ""
             },
             "require": {
@@ -1810,7 +1810,7 @@
                 }
             ],
             "description": "Interfaces for SQL resource abstraction.",
-            "time": "2018-04-06T11:15:17+00:00"
+            "time": "2018-07-31T12:24:35+00:00"
         },
         {
             "name": "dhii/stringable-helper-base",
@@ -2430,16 +2430,16 @@
         },
         {
             "name": "rebelcode/wp-cqrs-resource-models",
-            "version": "dev-develop",
+            "version": "v0.2-alpha1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/RebelCode/wp-cqrs-resource-models.git",
-                "reference": "d26ddc8cef8627ade845bf5d8dbd8e5faa90711d"
+                "reference": "4dfca05c2ec9e16927037e8930f55b0b73a7bff7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RebelCode/wp-cqrs-resource-models/zipball/d26ddc8cef8627ade845bf5d8dbd8e5faa90711d",
-                "reference": "d26ddc8cef8627ade845bf5d8dbd8e5faa90711d",
+                "url": "https://api.github.com/repos/RebelCode/wp-cqrs-resource-models/zipball/4dfca05c2ec9e16927037e8930f55b0b73a7bff7",
+                "reference": "4dfca05c2ec9e16927037e8930f55b0b73a7bff7",
                 "shasum": ""
             },
             "require": {
@@ -2491,7 +2491,7 @@
                 }
             ],
             "description": "Functionality for WordPress CQRS resource models.",
-            "time": "2018-06-27T08:51:16+00:00"
+            "time": "2018-07-31T12:18:43+00:00"
         }
     ],
     "packages-dev": [
@@ -4648,13 +4648,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rebelcode/wp-cqrs-resource-models": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.4 | ^7.0"
+        "php": "^5.4 | ^7.0",
+        "ext-mysqli": "^0.1"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc49da0fbcd03b642377dc3f8df6aa03",
+    "content-hash": "4070ed98ee645018d788245c862dc16b",
     "packages": [
         {
             "name": "dhii/args-list-validation",
@@ -258,16 +258,16 @@
         },
         {
             "name": "dhii/cqrs-resource-model-interface",
-            "version": "v0.1-alpha2",
+            "version": "v0.2-alpha1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/cqrs-resource-model-interface.git",
-                "reference": "38273c0314b80b9ab575ac8129071ee6fc0d5bdf"
+                "reference": "b58b1c41c24e7ea067d1c3c35c556d761f88aba2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/cqrs-resource-model-interface/zipball/38273c0314b80b9ab575ac8129071ee6fc0d5bdf",
-                "reference": "38273c0314b80b9ab575ac8129071ee6fc0d5bdf",
+                "url": "https://api.github.com/repos/Dhii/cqrs-resource-model-interface/zipball/b58b1c41c24e7ea067d1c3c35c556d761f88aba2",
+                "reference": "b58b1c41c24e7ea067d1c3c35c556d761f88aba2",
                 "shasum": ""
             },
             "require": {
@@ -275,6 +275,7 @@
             },
             "require-dev": {
                 "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/collections-interface": "^0.2-alpha1",
                 "dhii/expression-interface": "^0.2",
                 "dhii/php-cs-fixer-config": "dev-php-5.3",
                 "dhii/sql-interface": "^0.1",
@@ -290,7 +291,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-develop": "0.1.x-dev"
+                    "dev-develop": "0.2.x-dev"
                 }
             },
             "autoload": {
@@ -309,7 +310,7 @@
                 }
             ],
             "description": "Interfaces for a CQRS approach to resource models.",
-            "time": "2018-03-08T10:51:04+00:00"
+            "time": "2018-06-25T16:35:24+00:00"
         },
         {
             "name": "dhii/data-container-abstract",
@@ -2429,22 +2430,22 @@
         },
         {
             "name": "rebelcode/wp-cqrs-resource-models",
-            "version": "v0.1-alpha2",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/RebelCode/wp-cqrs-resource-models.git",
-                "reference": "2d73f5248aeba61c3604cbd14da18459e8c919a9"
+                "reference": "d26ddc8cef8627ade845bf5d8dbd8e5faa90711d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RebelCode/wp-cqrs-resource-models/zipball/2d73f5248aeba61c3604cbd14da18459e8c919a9",
-                "reference": "2d73f5248aeba61c3604cbd14da18459e8c919a9",
+                "url": "https://api.github.com/repos/RebelCode/wp-cqrs-resource-models/zipball/d26ddc8cef8627ade845bf5d8dbd8e5faa90711d",
+                "reference": "d26ddc8cef8627ade845bf5d8dbd8e5faa90711d",
                 "shasum": ""
             },
             "require": {
                 "dhii/callback-abstract": "^0.1-alpha4",
                 "dhii/container-helper-base": "^0.1",
-                "dhii/cqrs-resource-model-interface": "^0.1-alpha2",
+                "dhii/cqrs-resource-model-interface": "^0.2-alpha1",
                 "dhii/data-container-base": "^0.1",
                 "dhii/exception": "^0.1-alpha4",
                 "dhii/i18n-helper-base": "^0.1",
@@ -2456,6 +2457,7 @@
             },
             "require-dev": {
                 "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/collections-interface": "^0.2-alpha5",
                 "dhii/expression-interface": "^0.2",
                 "dhii/factory-interface": "^0.1-alpha2",
                 "dhii/invocable-interface": "^0.1-alpha1",
@@ -2489,7 +2491,7 @@
                 }
             ],
             "description": "Functionality for WordPress CQRS resource models.",
-            "time": "2018-06-14T16:50:25+00:00"
+            "time": "2018-06-27T08:51:16+00:00"
         }
     ],
     "packages-dev": [
@@ -4646,7 +4648,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "rebelcode/wp-cqrs-resource-models": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/src/Module/WpBookingsCqrsModule.php
+++ b/src/Module/WpBookingsCqrsModule.php
@@ -153,6 +153,7 @@ class WpBookingsCqrsModule extends AbstractBaseModule
                     return new BookingStatusWpdbSelectResourceModel(
                         $c->get('wpdb'),
                         $c->get('sql_expression_template'),
+                        $c->get('map_factory'),
                         $this->_normalizeArray($c->get('cqrs/bookings/select/tables')),
                         [
                             'status'       => 'status',
@@ -274,6 +275,7 @@ class WpBookingsCqrsModule extends AbstractBaseModule
                     return new UnbookedSessionsWpdbSelectResourceModel(
                         $c->get('wpdb'),
                         $c->get('sql_expression_template'),
+                        $c->get('map_factory'),
                         $this->_normalizeArray($c->get('cqrs/unbooked_sessions/select/tables')),
                         $fieldColumnMap,
                         $c->get($joinsServiceKey),

--- a/src/Module/WpBookingsCqrsModule.php
+++ b/src/Module/WpBookingsCqrsModule.php
@@ -91,6 +91,7 @@ class WpBookingsCqrsModule extends AbstractBaseModule
                     return new WpdbSelectResourceModel(
                         $c->get('wpdb'),
                         $c->get('sql_expression_template'),
+                        $c->get('map_factory'),
                         $this->_normalizeArray($c->get('cqrs/bookings/select/tables')),
                         $this->_normalizeArray($c->get('cqrs/bookings/select/field_column_map')),
                         $this->_normalizeArray($c->get('cqrs/bookings/select/joins'))
@@ -177,6 +178,7 @@ class WpBookingsCqrsModule extends AbstractBaseModule
                     return new WpdbSelectResourceModel(
                         $c->get('wpdb'),
                         $c->get('sql_expression_template'),
+                        $c->get('map_factory'),
                         $this->_normalizeArray($c->get('cqrs/transition_logs/select/tables')),
                         $this->_normalizeArray($c->get('cqrs/transition_logs/select/field_column_map')),
                         $this->_normalizeArray($c->get('cqrs/transition_logs/select/joins'))
@@ -238,6 +240,7 @@ class WpBookingsCqrsModule extends AbstractBaseModule
                     return new WpdbSelectResourceModel(
                         $c->get('wpdb'),
                         $c->get('sql_expression_template'),
+                        $c->get('map_factory'),
                         $this->_normalizeArray($c->get('cqrs/sessions/select/tables')),
                         $this->_normalizeArray($c->get('cqrs/sessions/select/field_column_map')),
                         $this->_normalizeArray($c->get('cqrs/sessions/select/joins'))
@@ -400,6 +403,7 @@ class WpBookingsCqrsModule extends AbstractBaseModule
                     return new WpdbSelectResourceModel(
                         $c->get('wpdb'),
                         $c->get('sql_expression_template'),
+                        $c->get('map_factory'),
                         $this->_normalizeArray($c->get('cqrs/session_rules/select/tables')),
                         $this->_normalizeArray($c->get('cqrs/session_rules/select/field_column_map')),
                         $this->_normalizeArray($c->get('cqrs/session_rules/select/joins'))

--- a/src/Wpdb/BookingStatusWpdbSelectResourceModel.php
+++ b/src/Wpdb/BookingStatusWpdbSelectResourceModel.php
@@ -2,6 +2,7 @@
 
 namespace RebelCode\Storage\Resource\WordPress\Wpdb;
 
+use Dhii\Collection\MapFactoryInterface;
 use Dhii\Expression\LogicalExpressionInterface;
 use Dhii\Output\TemplateInterface;
 use Dhii\Util\String\StringableInterface as Stringable;
@@ -32,6 +33,7 @@ class BookingStatusWpdbSelectResourceModel extends AbstractBaseWpdbSelectResourc
      *
      * @param wpdb                         $wpdb               The WPDB instance to use to prepare and execute queries.
      * @param TemplateInterface            $expressionTemplate The template for rendering SQL expressions.
+     * @param MapFactoryInterface          $mapFactory         The factory that creates maps, for the returned records.
      * @param array|stdClass|Traversable   $tables             The tables names (values) mapping to their aliases (keys)
      *                                                         or null for no aliasing.
      * @param string[]|Stringable[]        $fieldColumnMap     A map of field names to table column names.
@@ -41,12 +43,13 @@ class BookingStatusWpdbSelectResourceModel extends AbstractBaseWpdbSelectResourc
     public function __construct(
         wpdb $wpdb,
         TemplateInterface $expressionTemplate,
+        MapFactoryInterface $mapFactory,
         $tables,
         $fieldColumnMap,
         $groupColumns,
         $joins = []
     ) {
-        $this->_init($wpdb, $expressionTemplate, $tables, $fieldColumnMap, $joins);
+        $this->_init($wpdb, $expressionTemplate, $mapFactory, $tables, $fieldColumnMap, $joins);
         $this->_setGroupColumns($groupColumns);
     }
 

--- a/src/Wpdb/UnbookedSessionsWpdbSelectResourceModel.php
+++ b/src/Wpdb/UnbookedSessionsWpdbSelectResourceModel.php
@@ -2,14 +2,15 @@
 
 namespace RebelCode\Storage\Resource\WordPress\Wpdb;
 
+use Dhii\Collection\MapFactoryInterface;
 use Dhii\Expression\ExpressionInterface;
 use Dhii\Expression\LogicalExpressionInterface;
 use Dhii\Output\TemplateInterface;
 use Dhii\Storage\Resource\Sql\EntityFieldInterface;
+use Dhii\Util\String\StringableInterface as Stringable;
 use stdClass;
 use Traversable;
 use wpdb;
-use Dhii\Util\String\StringableInterface as Stringable;
 
 /**
  * The SELECT resource model for retrieving unbooked sessions.
@@ -56,6 +57,9 @@ class UnbookedSessionsWpdbSelectResourceModel extends AbstractBaseWpdbSelectReso
      * @param TemplateInterface                                                 $template       The template for
      *                                                                                          rendering SQL
      *                                                                                          expressions.
+     * @param MapFactoryInterface                                               $mapFactory     The factory that creates
+     *                                                                                          maps, for the returned
+     *                                                                                          records.
      * @param array|stdClass|Traversable                                        $tables         The tables names
      *                                                                                          (values) mapping to
      *                                                                                          their aliases (keys)
@@ -73,6 +77,7 @@ class UnbookedSessionsWpdbSelectResourceModel extends AbstractBaseWpdbSelectReso
     public function __construct(
         wpdb $wpdb,
         TemplateInterface $template,
+        MapFactoryInterface $mapFactory,
         $tables,
         $fieldColumnMap,
         $joins,
@@ -80,7 +85,7 @@ class UnbookedSessionsWpdbSelectResourceModel extends AbstractBaseWpdbSelectReso
         $grouping,
         $exprBuilder
     ) {
-        $this->_init($wpdb, $template, $tables, $fieldColumnMap, $joins);
+        $this->_init($wpdb, $template, $mapFactory, $tables, $fieldColumnMap, $joins);
         $this->internalCondition = $condition;
         $this->grouping          = $grouping;
         $this->exprBuilder       = $exprBuilder;


### PR DESCRIPTION
Updates the CQRS package dependencies and fixes the classes in this module to conform to the latest API changes.

----

The following changes need to be made before merging:

- [ ] Update version constraint for dependency `rebelcode/wp-cqrs-resource-models` (currently set as `dev-develop`) when a new release is available for that package.